### PR TITLE
added md5 hashing to the quota identifer based on operations

### DIFF
--- a/product/product.go
+++ b/product/product.go
@@ -71,6 +71,7 @@ type OperationGroup struct {
 
 // An OperationConfig is a group of Operations
 type OperationConfig struct {
+	ID                      string      `json:"-"`
 	APISource               string      `json:"apiSource"`
 	Attributes              []Attribute `json:"attributes,omitempty"`
 	Operations              []Operation `json:"operations"`
@@ -108,6 +109,8 @@ func (oc *OperationConfig) UnmarshalJSON(data []byte) error {
 	sort.Slice(oc.Operations, func(i, j int) bool {
 		return oc.Operations[i].Resource < oc.Operations[j].Resource
 	})
+
+	oc.ID = fmt.Sprintf("%s-%x", oc.APISource, md5hash(oc.Operations))
 
 	return nil
 }
@@ -293,7 +296,7 @@ func (p *APIProduct) authorize(authContext *auth.Context, target, path, method s
 			valid, hint = oc.isValidOperation(target, path, method, hints)
 			if valid {
 				target := AuthorizedOperation{
-					ID:            fmt.Sprintf("%s-%s-%s-%x", p.Name, authContext.Application, oc.APISource, md5hash(oc.Operations)),
+					ID:            fmt.Sprintf("%s-%s-%s", p.Name, authContext.Application, oc.ID),
 					QuotaLimit:    p.QuotaLimitInt,
 					QuotaInterval: p.QuotaIntervalInt,
 					QuotaTimeUnit: p.QuotaTimeUnit,

--- a/product/product_test.go
+++ b/product/product_test.go
@@ -609,11 +609,11 @@ const productJSON = `
           {
             "resource": "/all",
             "methods": [
-							"GET",
-							"POST",
-							"PATCH",
-							"PUT",
-							"DELETE"
+              "GET",
+              "POST",
+              "PATCH",
+              "PUT",
+              "DELETE"
             ]
           },
           {

--- a/product/product_test.go
+++ b/product/product_test.go
@@ -606,7 +606,7 @@ const productJSON = `
       {
         "apiSource": "quota-demo",
         "operations": [
-					{
+          {
             "resource": "/all",
             "methods": [
 							"GET",
@@ -615,20 +615,20 @@ const productJSON = `
 							"PUT",
 							"DELETE"
             ]
-					},
+          },
           {
             "resource": "/put",
             "methods": [
               "PUT"
             ]
-					},
-					{
+          },
+          {
             "resource": "/post",
             "methods": [
               "POST"
             ]
-					},
-					{
+          },
+          {
             "resource": "/get",
             "methods": [
               "GET"

--- a/product/product_test.go
+++ b/product/product_test.go
@@ -545,6 +545,9 @@ func TestParseJSONWithOperations(t *testing.T) {
 	if len(oc.Operations) != 4 {
 		t.Fatalf("want 1 Operation")
 	}
+	if want := "quota-demo-98c34c322202a4f9e01aea733326a129"; oc.ID != want {
+		t.Errorf("want OperationConfig.ID: '%s', got '%s'", want, oc.ID)
+	}
 	var op Operation
 
 	op = oc.Operations[0]


### PR DESCRIPTION
The quota identifiers for those with operationgroups are now formatted `Product-Application-APISource-md5hash_of_operations`

fixes #34

