### PR TITLE
fix panic during quota sync

### DIFF
--- a/analytics/legacy_analytics.go
+++ b/analytics/legacy_analytics.go
@@ -64,7 +64,11 @@ func (oa *legacyAnalytics) SendRecords(authContext *auth.Context, records []Reco
 	}
 	defer resp.Body.Close()
 
-	buf := bytes.NewBuffer(make([]byte, 0, resp.ContentLength))
+	bufLen := resp.ContentLength
+	if bufLen < bytes.MinRead {
+		bufLen = bytes.MinRead
+	}
+	buf := bytes.NewBuffer(make([]byte, 0, bufLen))
 	_, err = buf.ReadFrom(resp.Body)
 	if err != nil {
 		return err

--- a/quota/bucket.go
+++ b/quota/bucket.go
@@ -162,7 +162,11 @@ func (b *bucket) sync() error {
 	}
 	defer resp.Body.Close()
 
-	buf := bytes.NewBuffer(make([]byte, 0, resp.ContentLength))
+	bufLen := resp.ContentLength
+	if bufLen < bytes.MinRead {
+		bufLen = bytes.MinRead
+	}
+	buf := bytes.NewBuffer(make([]byte, 0, bufLen))
 	if _, err = buf.ReadFrom(resp.Body); err != nil {
 		return errors.Wrap(err, "read body")
 	}


### PR DESCRIPTION
A response ContentLength can occasionally be -1, this ensures it doesn't break. (This also optimizes the buffer length.)

Fixes #136