### PR TITLE
Add condition to validate bucket is not in-use before deleting

### DIFF
--- a/quota/bucket.go
+++ b/quota/bucket.go
@@ -205,7 +205,9 @@ func (b *bucket) sync() error {
 func (b *bucket) needToDelete() bool {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
-	return b.request.Weight == 0 && b.now().After(b.checked.Add(b.deleteAfter))
+	// Do not delete an in-use bucket to avoid allowing requests when a new bucket is created and is not yet synced to the remote service.
+	inUse := b.result != nil && b.result.Used != 0
+	return !inUse && b.request.Weight == 0 && b.now().After(b.checked.Add(b.deleteAfter))
 }
 
 func (b *bucket) needToSync() bool {


### PR DESCRIPTION
If a bucket has exhausted quota and receives no requests for 10 minutes (the default deletion period for a bucket when no requests have utilized the bucket), there is a brief period where any new requests coming into the envoy adapter will create a new bucket and will allow requests, even if the quota is exhausted, until the new bucket can sync to the remote.

This change adds a check to the deletion logic to ensure any bucket with a quota result and allocated usage will not be deleted.